### PR TITLE
Bumped telemetry to 0.4 or 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule SMPPEXTelemetry.MixProject do
   defp deps do
     [
       {:smppex, ">= 3.0.3"},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:earmark, "~> 1.4", only: :dev},
       {:ex_doc, "~> 0.23", only: :dev}
     ]


### PR DESCRIPTION
As `telemetry_poller ~> 1.0` fixed its telemetry dependency to `~> 1.0` it results into conflict with this package. Changing this package's telemetry requirement resolves the conflict.